### PR TITLE
add type defs so module can be imported as-is

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "cgtjs",
   "module": "cgtjs/index.ts",
+  "types": "cgtjs/index.ts",
   "type": "module",
   "version": "0.1.0",
   "devDependencies": {


### PR DESCRIPTION
Previously, importing this repo as `github:ishehadeh/cgtjs` would fail when running tsc.