### PR TITLE
fix reversible check comparison ignoring 0

### DIFF
--- a/cgtjs/MoveSet.ts
+++ b/cgtjs/MoveSet.ts
@@ -71,7 +71,7 @@ export class MoveSet extends CanonicalForm {
   bypassReversibleL() {
     for (let i = 0; i < this.left.length; ++i) {
       for (const lR of this.left[i].rightMoves) {
-        if (lR.partialCompare(this) ?? Number.isNaN(0)) {
+        if ((lR.partialCompare(this) ?? NaN) <= 0) {
           const moves = [...lR.leftMoves];
           if (moves.length > 0) {
             this.left[i] = moves[0];
@@ -122,7 +122,7 @@ export class MoveSet extends CanonicalForm {
   bypassReversibleR() {
     for (let i = 0; i < this.right.length; ++i) {
       for (const rL of this.right[i].leftMoves) {
-        if (rL.partialCompare(this) ?? Number.isNaN(0)) {
+        if ((rL.partialCompare(this) ?? NaN) >= 0) {
           const moves = [...rL.rightMoves];
           if (moves.length > 0) {
             this.right[i] = moves[0];

--- a/test/Normalize.test.ts
+++ b/test/Normalize.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+import { canonicalForm, MoveSet } from '../cgtjs/MoveSet.ts';
+import { NumberUpStar } from '../cgtjs/NumberUpStar.ts';
+
+test('normalize: {1/2 | 2} is 1 (left reversible bypass)', () => {
+  const half = canonicalForm([new NumberUpStar(0n)], [new NumberUpStar(1n)]);
+  const g = new MoveSet([half], [new NumberUpStar(2n)]);
+  const n = g.clone().normalize();
+
+  expect(n.partialCompare(new NumberUpStar(1n)), `got ${n.toString()}`).toBe(0);
+});
+
+test('normalize: {-2 | -1/2} is -1 (right reversible bypass)', () => {
+  const negHalf = canonicalForm([new NumberUpStar(-1n)], [new NumberUpStar(0n)]);
+  const g = new MoveSet([new NumberUpStar(-2n)], [negHalf]);
+  const n = g.clone().normalize();
+
+  expect(n.partialCompare(new NumberUpStar(-1n)), `got ${n.toString()}`).toBe(0);
+});

--- a/test/NumberUpStar.test.ts
+++ b/test/NumberUpStar.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { DyadicRational } from '../cgtjs/DyadicRational.ts';
-import { canonicalForm } from '../cgtjs/MoveSet.ts';
+import { canonicalForm, MoveSet } from '../cgtjs/MoveSet.ts';
 import { NumberUpStar } from '../cgtjs/NumberUpStar.ts';
 
 test('NumberUpStar comparison 0 || *', () => {
@@ -21,10 +21,16 @@ test('NumberUpStar compares up & up move set with star', () => {
 });
 
 test('NumberUpStar compares up with rational move set', () => {
-  const b = canonicalForm([new NumberUpStar(new DyadicRational(11, 2))], [new NumberUpStar(new DyadicRational(1, 1))]);
+  const b = canonicalForm(
+    [new NumberUpStar(new DyadicRational(11n, 2n))],
+    [new NumberUpStar(new DyadicRational(1n, 1n))],
+  );
+  expect(b, `expected b to be { 11/4 | 1/2 } but got ${b.toString()}`).toBeInstanceOf(MoveSet);
 
-  expect(new NumberUpStar(new DyadicRational(2)).partialCompare(b)).toBe(-1);
-  expect(new NumberUpStar(new DyadicRational(2)).partialCompare(new NumberUpStar(new DyadicRational(11, 2)))).toBe(-1);
+  expect(new NumberUpStar(new DyadicRational(2n)).partialCompare(b)).toBe(null);
+  expect(new NumberUpStar(new DyadicRational(2n)).partialCompare(new NumberUpStar(new DyadicRational(11n, 2n)))).toBe(
+    -1,
+  );
 });
 
 test('[*] => 0', () => {


### PR DESCRIPTION
Not sure what happened here, but it basically just checks if -1, 0, or 1 is truthy, instead of checking for either not -1 or not 1